### PR TITLE
FINUFFT v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 scipy<=1.3.3
-finufftpy
+finufft
 pyfftw
 matplotlib
+tornado

--- a/src/ftk.py
+++ b/src/ftk.py
@@ -477,29 +477,28 @@ def rotations_brute_force(fimages, Shat, n_gamma, pf_grid, Nfine):
 
     fx1 = quad_wts_sq * Shat_rot
 
-    fx1 = fx1.reshape((n_gamma * n_templates, ngridr*ngridp))  # for 2d1
-    
+    fx1 = fx1.reshape((n_templates * n_gamma, ngridr * ngridp))
+
     T = 2
     dx = dy = T / N
 
-    templates_rot = np.empty((n_gamma * n_templates, N, N),
+    templates_rot = np.empty((n_templates * n_gamma, N, N),
                              dtype=np.complex128)
 
     upsampfac = 1.25
     isign = 1
     eps = 1e-2
 
-    finufft.nufft2d1(wx * dx, wy * dy, fx1, (N,N), isign=isign, eps=eps,
+    finufft.nufft2d1(wx * dx, wy * dy, fx1, (N, N), isign=isign, eps=eps,
                            out=templates_rot, upsampfac=upsampfac)
 
-    #print(templates_rot.shape)
-    templates_rot = templates_rot.reshape(n_templates, n_gamma,N,N) / (4 * np.pi ** 2)
-    # templates_rot: (trx, try, γ, te)  ###? no
-    
-    #templates_rot = templates_rot.transpose((3, 2, 1, 0)).copy()
-    templates_rot = templates_rot.transpose((0,1,3,2)).copy()
-    # templates_rot: (te, γ, try, trx)  
-    
+    templates_rot = templates_rot.reshape(n_templates, n_gamma, N, N)
+    templates_rot = templates_rot / (4 * np.pi ** 2)
+    # templates_rot: (te, γ, trx, try)
+
+    templates_rot = templates_rot.transpose((0, 1, 3, 2)).copy()
+    # templates_rot: (te, γ, try, trx)
+
     ftemplates_rot = fft2(ifftshift(templates_rot, axes=(-2, -1)))
     # ftemplates_rot: (te, γ, trky, trkx)
 

--- a/src/ftk.py
+++ b/src/ftk.py
@@ -243,7 +243,7 @@ def pft_to_cartesian(Shat, T, N, pf_grid):
 
         gxx = gxx*dx*dy/(4*np.pi**2)
 
-        templates1[k, :, :] = np.real(gxx.transpose((1, 0)))
+        templates1[k, :, :] = np.real(gxx)
 
     return templates1
 

--- a/src/ftk.py
+++ b/src/ftk.py
@@ -196,10 +196,9 @@ def cartesian_to_pft(templates, T, pf_grid):
     for k in range(n_templates):
         template = templates[k, :, :]
 
-        # Need to force Fortran ordering because that's what the FINUFFT
+        # Need to force complex values because that's what the FINUFFT
         # interface expects.
-        gg = np.asarray(template,dtype=np.complex128)
-        #gg = np.asfortranarray(template.transpose((1, 0)))
+        gg = np.asarray(template, dtype=np.complex128)
 
         isign = -1
         eps = 1e-6


### PR DESCRIPTION
I attempted to rewrite the 3 finufft calls to use v2. I probably messed something up, since I had a fever when I did it. In particular I was pretty confused about the BFR 4d-array that was sent to the old "many" interface. I also removed the transpose ops and fortran array stuff. But I don't believe it yet, since the FTK errors are of order 1e-4 whether I transpose or not.. which doesn't make sense to me. So, Joakim, maybe you can fix up sometime.
